### PR TITLE
Fix hellopacket documentation: Parameter order

### DIFF
--- a/haka/release/v0.3.0/doc/user/tutorial/hellopacket.html
+++ b/haka/release/v0.3.0/doc/user/tutorial/hellopacket.html
@@ -129,7 +129,7 @@ Haka, being as much a language as a network tool, needs its own helloworld, call
 <h2>6.1.2. How-to<a class="headerlink" href="#how-to" title="Permalink to this headline">¶</a></h2>
 <p>Launch <tt class="docutils literal"><span class="pre">hakapcap</span></tt> with a pcap file and a lua script file as arguments.</p>
 <div class="highlight-console"><div class="highlight"><pre><span class="gp">$</span> <span class="nb">cd</span> &lt;haka_install_path&gt;/share/haka/sample/hellopacket
-<span class="gp">$</span> hakapcap hellopacket.pcap hellopacket.lua
+<span class="gp">$</span> hakapcap hellopacket.lua hellopacket.pcap
 </pre></div>
 </div>
 <p>Hakapcap will first dump infos about registered dissectors and


### PR DESCRIPTION
Example did not meet the proper usage for the most recent release.